### PR TITLE
Free the engine on exit, per norns SC API. Fixes #2.

### DIFF
--- a/lib/Engine_Choir.sc
+++ b/lib/Engine_Choir.sc
@@ -169,4 +169,10 @@ Engine_Choir : CroneEngine {
     });
 
   }
+
+  // Free the playing notes and the engine on exit.
+  free {
+    notes.do { |angels| angels.do { |vow| vow.free } };
+    pg.free;
+  }
 }


### PR DESCRIPTION
Exit with grace, and free the angels.

![](https://upload.wikimedia.org/wikipedia/commons/thumb/0/0c/WWStoryRome.jpg/640px-WWStoryRome.jpg)

My SuperCollider skills are weak, but slowly working on it. I hope this fix covers all the cases, please let me know if not. I also failed to write this in a branch instead of `main`. Thanks for great script for norns.